### PR TITLE
Change default slimjar version

### DIFF
--- a/gradle-plugin/src/main/kotlin/io/github/slimjar/func/Declarations.kt
+++ b/gradle-plugin/src/main/kotlin/io/github/slimjar/func/Declarations.kt
@@ -42,7 +42,7 @@ val Project.slimInjectToIsolated: Boolean
     get() = findProperty("slimjar.default.isolated.inject")?.toString()?.toBoolean() ?: true
 
 val Project.slimVersion: String
-    get() = findProperty("slimjar.version")?.toString() ?: "1.2.1"
+    get() = findProperty("slimjar.version")?.toString() ?: "1.2.3"
 
 /**
  * Adds the slimJar dependency to the project


### PR DESCRIPTION
SlimJar 1.2.1 does not exist in your repository.
As such, trying to load the plugin without declaring `slimjar.version=1.2.3` in gradle.properties causes an error.